### PR TITLE
fixing stable helm URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN wget -O /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-rel
 RUN wget -q http://storage.googleapis.com/kubernetes-helm/helm-${HELM_VERSION}-linux-amd64.tar.gz -O - | tar -xzO linux-amd64/helm > /usr/local/bin/helm && \
   chmod +x /usr/local/bin/helm
 
-RUN helm init --client-only
+RUN helm init --client-only --stable-repo-url https://charts.helm.sh/stable
 
 COPY ./helm-package.sh /usr/bin/helm-package
 


### PR DESCRIPTION
It started breaking since stable repo was moved

```
  Step 17/20 : RUN helm init --client-only
   ---> Running in 640d33e86f75
  Creating /usr/local/helm 
  Creating /usr/local/helm/repository 
  Creating /usr/local/helm/repository/cache 
  Creating /usr/local/helm/repository/local 
  Creating /usr/local/helm/plugins 
  Creating /usr/local/helm/starters 
  Creating /usr/local/helm/cache/archive 
  Creating /usr/local/helm/repository/repositories.yaml 
  Adding stable repo with URL: https://kubernetes-charts.storage.googleapis.com 
  Error: Looks like "https://kubernetes-charts.storage.googleapis.com" is not a valid chart repository or cannot be reached: Failed to fetch https://kubernetes-charts.storage.googleapis.com/index.yaml : 403 Forbidden
  The command '/bin/sh -c helm init --client-only' returned a non-zero code: 1
```